### PR TITLE
RDKE-149: add rootfs_post process functions

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -9,7 +9,7 @@ IMAGE_INSTALL = " \
                  "
 inherit core-image
 
-inherit custom-rootfs-configuration
+inherit custom-rootfs-creation
 
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE_append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"
@@ -19,3 +19,20 @@ create_init_link() {
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "create_init_link; "
+
+# Community specific rootfs_postprocess func
+ROOTFS_POSTPROCESS_COMMAND += "update_dropbearkey_path; "
+update_dropbearkey_path() {
+   if [ -f "${IMAGE_ROOTFS}/lib/systemd/system/dropbearkey.service" ]; then
+        sed -i 's/\/etc\/dropbear/\/opt\/dropbear/g' ${IMAGE_ROOTFS}/lib/systemd/system/dropbearkey.service
+   fi
+}
+
+# RDK-50713: Remove securemount dependency from wpa_supplicant.service
+# Revert once the actual fix is merged as part of the ticket
+ROOTFS_POSTPROCESS_COMMAND += "remove_securemount_dep_patch;"
+
+remove_securemount_dep_patch() {
+   sed -i '/Requires=securemount.service/d' ${IMAGE_ROOTFS}/lib/systemd/system/wpa_supplicant.service
+   sed -i 's/\bsecuremount\.service\b//g' ${IMAGE_ROOTFS}/lib/systemd/system/wpa_supplicant.service
+}


### PR DESCRIPTION
Reason for change: for testing application image
Test Procedure: Build and verify apps
Risks: Low