### PR TITLE
REFPLTV-2409 : WPEFramework port 9998 is not open for external network communication in RDK-E application build

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -36,3 +36,12 @@ remove_securemount_dep_patch() {
    sed -i '/Requires=securemount.service/d' ${IMAGE_ROOTFS}/lib/systemd/system/wpa_supplicant.service
    sed -i 's/\bsecuremount\.service\b//g' ${IMAGE_ROOTFS}/lib/systemd/system/wpa_supplicant.service
 }
+
+
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains("DISTRO_FEATURES", "debug-variant", "wpeframework_binding_patch; ", "", d)}'
+
+wpeframework_binding_patch(){
+    sed -i "s/127.0.0.1/0.0.0.0/g" ${IMAGE_ROOTFS}/etc/WPEFramework/config.json
+}
+
+


### PR DESCRIPTION
Reason for change: Temporary change to make port 9998 open for external network communication to enable TDK testing of RDKServices. This is enabled only for dev builds and can be removed when TTC/TTS mechanism for RDK services communication is established.

Test Procedure: Verify rest API(s) are working.
Risks: Low
Upstream-Status: Pending
Source:RDKM