### PR TITLE
RDKVREFPLT-3163: pkggrp version update v1.1.0

### DIFF
--- a/recipes-core/packagegroups/packagegroup-application-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-application-layer.bb
@@ -6,7 +6,7 @@ LICENSE = "MIT"
 inherit packagegroup
 
 ##Change the version number for each release.
-PV = "1.0.1"
+PV = "1.1.0"
 
 RDEPENDS_packagegroup-application-layer = " \
                                            residentui \


### PR DESCRIPTION
Incompatible with old build tools; require meta-stack-layering and meta-rdk-auxiliary layers along with meta-image-support