### PR TITLE
keymapping: add descriptions for keymappings and OK button

### DIFF
--- a/recipes-thirdparty/cobalt-keymap/files/keymapping.json
+++ b/recipes-thirdparty/cobalt-keymap/files/keymapping.json
@@ -1,33 +1,45 @@
 {
   "keymappings": [
     {
+      "description": "YouTube button",
       "keycode": 62,
       "mapped": {
         "keycode": 179
       }
     },
     {
+      "description": "Info overlay",
       "keycode": 191,
       "mapped": {
         "keycode": 358
       }
     },
     {
+      "description": "Channel up",
       "keycode": 104,
       "mapped": {
         "keycode": 402
       }
     },
     {
+      "description": "Channel down",
       "keycode": 109,
       "mapped": {
         "keycode": 403
       }
     },
     {
+      "description": "Back",
       "keycode": 14,
       "mapped": {
         "keycode": 1
+      }
+    },
+    {
+      "description": "OK/Select",
+      "keycode": 353,
+      "mapped": {
+        "keycode": 28
       }
     }
   ]


### PR DESCRIPTION
- Add mapping to the OK button
- Added descriptions for new keymappings
- Included details for YouTube button, Info overlay, Channel up, Channel down, Back, and OK/Select
-  The `description` field is ignored by the JSON parser but serve as inline documentation in the JSON