### PR TITLE
RDKEVL-7365:[RPI] OSS and common metalayers update

### DIFF
--- a/conf/machine/include/application.inc
+++ b/conf/machine/include/application.inc
@@ -1,5 +1,8 @@
 # To support layered ipk generation
-APP_LAYER_ARCH ??= "${MACHINE}-application"
 
+LAYER_EXTENSION = "-application"
+
+APP_LAYER_ARCH ??= "${MACHINE}${LAYER_EXTENSION}"
 PACKAGE_EXTRA_ARCHS:append = " ${APP_LAYER_ARCH}"
+
 require package_revisions.inc

--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -18,7 +18,6 @@ BBLAYERS ?= " \
 "
 
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_OSS_REFERENCE}' if os.path.isfile('${MANIFEST_PATH_COMMON_OSS_REFERENCE}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_RELEASE}' if os.path.isfile('${MANIFEST_PATH_OSS_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_EXT}' if os.path.isfile('${MANIFEST_PATH_OSS_EXT}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_PRODUCT_LAYER}' if os.path.isfile('${MANIFEST_PATH_PRODUCT_LAYER}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_MW_RELEASE}' if os.path.isfile('${MANIFEST_PATH_MW_RELEASE}/conf/layer.conf') else ''}"


### PR DESCRIPTION
Reason: Add LAYER_EXTENSION setting and remove MANIFEST_PATH_OSS_RELEASE/meta-oss-reference-release in bblayers