### PR TITLE
RTK-1961 Amazon Prime app displays a black screen on launch with Kernel 6.12.38

### DIFF
--- a/recipes-core/images/application-test-image.bb
+++ b/recipes-core/images/application-test-image.bb
@@ -14,6 +14,7 @@ inherit core-image custom-rootfs-creation extrausers
 EXTRA_USERS_PARAMS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'amazon_non_root_support', '''\
     groupadd -g 1001 amazon;\
     useradd -u 1001 -g amazon -M -r -s /bin/sh amazon;\
+    usermod -a -G video amazon;\
 ''', '', d)}"
 
 IMAGE_ROOTFS_SIZE ?= "8192"


### PR DESCRIPTION
Reason for change:
1. Added the amazon user to video group to get the required DMA heap dev node access

Test Procedure: build and amazon playback verified

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com